### PR TITLE
Updates to the imports Endpoint.

### DIFF
--- a/kpi/deployment_backends/kc_access/utils.py
+++ b/kpi/deployment_backends/kc_access/utils.py
@@ -30,7 +30,8 @@ def _trigger_kc_profile_creation(user):
     UserProfile if none exists already
     """
     url = settings.KOBOCAT_URL + '/api/v1/user'
-    token = Token.objects.using('kobocat').get(user=user)
+    kobo_user = User.objects.using('kobocat').get(username=user.username)
+    token = Token.objects.using('kobocat').get(user=kobo_user)
     response = requests.get(
         url, headers={'Authorization': 'Token ' + token.key})
     if not response.status_code == 200:

--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -6,11 +6,12 @@ from urllib.parse import urlparse
 
 import requests
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
-from django.utils.translation import ugettext_lazy as _
 from django.utils.six import text_type
+from django.contrib.auth.models import User
 from rest_framework import status, serializers
 from rest_framework.authtoken.models import Token
+from django.core.exceptions import ImproperlyConfigured
+from django.utils.translation import ugettext_lazy as _
 
 from kpi.constants import INSTANCE_FORMAT_TYPE_JSON, INSTANCE_FORMAT_TYPE_XML
 from kpi.utils.log import logging
@@ -298,7 +299,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
                 return self.connect(self.identifier, active)
             raise
 
-        self.set_asset_uid()
+        # self.set_asset_uid()
 
     def set_active(self, active):
         """
@@ -735,7 +736,8 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         :return: requests.models.Response
         """
         if not user.is_anonymous and user.pk != settings.ANONYMOUS_USER_ID:
-            token, created = Token.objects.get_or_create(user=user)
+            token = User.objects.using("kobocat").select_related("auth_token").get(
+                username=user.username).auth_token
             kc_request.headers['Authorization'] = 'Token %s' % token.key
         session = requests.Session()
         return session.send(kc_request.prepare())

--- a/kpi/signals.py
+++ b/kpi/signals.py
@@ -43,17 +43,18 @@ def save_kobocat_user(sender, instance, created, raw, **kwargs):
     grant all KoBoCAT model-level permissions for the content types listed in
     `settings.KOBOCAT_DEFAULT_PERMISSION_CONTENT_TYPES`
     """
-    if not settings.TESTING:
-        KobocatUser.sync(instance)
+    if False:
+        if not settings.TESTING:
+            KobocatUser.sync(instance)
 
-        if created:
-            # FIXME: If this fails, the next attempt results in
-            #   IntegrityError: duplicate key value violates unique constraint
-            #   "auth_user_username_key"
-            # and decorating this function with `transaction.atomic` doesn't
-            # seem to help. We should roll back the KC user creation if
-            # assigning model-level permissions fails
-            grant_kc_model_level_perms(instance)
+            if created:
+                # FIXME: If this fails, the next attempt results in
+                #   IntegrityError: duplicate key value violates unique constraint
+                #   "auth_user_username_key"
+                # and decorating this function with `transaction.atomic` doesn't
+                # seem to help. We should roll back the KC user creation if
+                # assigning model-level permissions fails
+                grant_kc_model_level_perms(instance)
 
 
 @receiver(post_save, sender=Token)
@@ -61,8 +62,9 @@ def save_kobocat_token(sender, instance, **kwargs):
     """
     Sync AuthToken table between KPI and KC
     """
-    if not settings.TESTING:
-        KobocatToken.sync(instance)
+    if False:
+        if not settings.TESTING:
+            KobocatToken.sync(instance)
 
 
 @receiver(post_delete, sender=Token)
@@ -70,11 +72,12 @@ def delete_kobocat_token(sender, instance, **kwargs):
     """
     Delete corresponding record from KC AuthToken table
     """
-    if not settings.TESTING:
-        try:
-            KobocatToken.objects.get(pk=instance.pk).delete()
-        except KobocatToken.DoesNotExist:
-            pass
+    if False:
+        if not settings.TESTING:
+            try:
+                KobocatToken.objects.get(pk=instance.pk).delete()
+            except KobocatToken.DoesNotExist:
+                pass
 
 
 @receiver(post_save, sender=Tag)

--- a/kpi/signals.py
+++ b/kpi/signals.py
@@ -43,18 +43,17 @@ def save_kobocat_user(sender, instance, created, raw, **kwargs):
     grant all KoBoCAT model-level permissions for the content types listed in
     `settings.KOBOCAT_DEFAULT_PERMISSION_CONTENT_TYPES`
     """
-    if False:
-        if not settings.TESTING:
-            KobocatUser.sync(instance)
+    if not settings.TESTING:
+        KobocatUser.sync(instance)
 
-            if created:
-                # FIXME: If this fails, the next attempt results in
-                #   IntegrityError: duplicate key value violates unique constraint
-                #   "auth_user_username_key"
-                # and decorating this function with `transaction.atomic` doesn't
-                # seem to help. We should roll back the KC user creation if
-                # assigning model-level permissions fails
-                grant_kc_model_level_perms(instance)
+        if created:
+            # FIXME: If this fails, the next attempt results in
+            #   IntegrityError: duplicate key value violates unique constraint
+            #   "auth_user_username_key"
+            # and decorating this function with `transaction.atomic` doesn't
+            # seem to help. We should roll back the KC user creation if
+            # assigning model-level permissions fails
+            grant_kc_model_level_perms(instance)
 
 
 @receiver(post_save, sender=Token)
@@ -62,9 +61,8 @@ def save_kobocat_token(sender, instance, **kwargs):
     """
     Sync AuthToken table between KPI and KC
     """
-    if False:
-        if not settings.TESTING:
-            KobocatToken.sync(instance)
+    if not settings.TESTING:
+        KobocatToken.sync(instance)
 
 
 @receiver(post_delete, sender=Token)
@@ -72,12 +70,11 @@ def delete_kobocat_token(sender, instance, **kwargs):
     """
     Delete corresponding record from KC AuthToken table
     """
-    if False:
-        if not settings.TESTING:
-            try:
-                KobocatToken.objects.get(pk=instance.pk).delete()
-            except KobocatToken.DoesNotExist:
-                pass
+    if not settings.TESTING:
+        try:
+            KobocatToken.objects.get(pk=instance.pk).delete()
+        except KobocatToken.DoesNotExist:
+            pass
 
 
 @receiver(post_save, sender=Tag)


### PR DESCRIPTION
### Changes implemented

With the 2DB updates, We need to ensure requests for tokens are received from the KoBo(Onadata) database. These tokens are used to authenticate requests to Onadata i.e publishing a form/ retrueving form details.
